### PR TITLE
Redact scoped package info

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scarf/scarf",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Scarf is like Google Analytics for your npm packages. Gain insights into how your packages are installed and used, and by which companies.",
   "main": "report.js",
   "files": [

--- a/report.js
+++ b/report.js
@@ -39,7 +39,7 @@ function redactScopedPackageInfo (dependencyInfo) {
     dependencyInfo.grandparent.version = privateVersionRewrite
   }
   if (dependencyInfo.rootPackage && dependencyInfo.rootPackage.name.match(scopedRegex)) {
-    dependencyInfo.rootPackage.name = '@private/private'
+    dependencyInfo.rootPackage.name = privateVersionRewrite
     dependencyInfo.rootPackage.version = privateVersionRewrite
   }
   return dependencyInfo

--- a/report.js
+++ b/report.js
@@ -30,6 +30,21 @@ const userHasOptedIn = (rootPackage) => {
   return (rootPackage && rootPackage.scarfSettings && rootPackage.scarfSettings.enabled) || process.env.SCARF_ANALYTICS === 'true'
 }
 
+function redactScopedPackageInfo(dependencyInfo) {
+  const scopedRegex = /\@\S+\//
+  const privatePackageRewrite = '@private/private'
+  const privateVersionRewrite = '0'
+  if (dependencyInfo.grandparent && dependencyInfo.grandparent.name.match(scopedRegex)) {
+    dependencyInfo.grandparent.name = privatePackageRewrite
+    dependencyInfo.grandparent.version = privateVersionRewrite
+  }
+  if (dependencyInfo.root && dependencyInfo.root.name.match(scopedRegex)) {
+    dependencyInfo.root.name = '@private/private'
+    dependencyInfo.root.version = privateVersionRewrite
+  }
+  return dependencyInfo
+}
+
 async function getDependencyInfo () {
   const moduleSeparated = path.resolve(__dirname).split('node_modules')
   const dependentPath = moduleSeparated.slice(0, moduleSeparated.length - 1).join('node_modules')
@@ -57,6 +72,7 @@ async function getDependencyInfo () {
       }
 
       dependencyInfo.parent.scarfSettings = Object.assign(makeDefaultSettings(), dependencyInfo.parent.scarfSettings || {})
+      redactScopedPackageInfo(dependencyInfo)
 
       return resolve(dependencyInfo)
     })
@@ -225,7 +241,7 @@ function findScarfInSubDepTree (pathToDep, deps) {
         {
           name: depName,
           version: deps[depName].version,
-          scarfSettings: deps[depName].scarfSettings
+          scarfSettings: deps[depName].scarfSettings,
         }
       ])
       const result = findScarfInSubDepTree(newPathToDep, deps[depName].dependencies)

--- a/report.js
+++ b/report.js
@@ -30,17 +30,17 @@ const userHasOptedIn = (rootPackage) => {
   return (rootPackage && rootPackage.scarfSettings && rootPackage.scarfSettings.enabled) || process.env.SCARF_ANALYTICS === 'true'
 }
 
-function redactScopedPackageInfo(dependencyInfo) {
-  const scopedRegex = /\@\S+\//
+function redactScopedPackageInfo (dependencyInfo) {
+  const scopedRegex = /@\S+\//
   const privatePackageRewrite = '@private/private'
   const privateVersionRewrite = '0'
   if (dependencyInfo.grandparent && dependencyInfo.grandparent.name.match(scopedRegex)) {
     dependencyInfo.grandparent.name = privatePackageRewrite
     dependencyInfo.grandparent.version = privateVersionRewrite
   }
-  if (dependencyInfo.root && dependencyInfo.root.name.match(scopedRegex)) {
-    dependencyInfo.root.name = '@private/private'
-    dependencyInfo.root.version = privateVersionRewrite
+  if (dependencyInfo.rootPackage && dependencyInfo.rootPackage.name.match(scopedRegex)) {
+    dependencyInfo.rootPackage.name = '@private/private'
+    dependencyInfo.rootPackage.version = privateVersionRewrite
   }
   return dependencyInfo
 }
@@ -241,7 +241,7 @@ function findScarfInSubDepTree (pathToDep, deps) {
         {
           name: depName,
           version: deps[depName].version,
-          scarfSettings: deps[depName].scarfSettings,
+          scarfSettings: deps[depName].scarfSettings
         }
       ])
       const result = findScarfInSubDepTree(newPathToDep, deps[depName].dependencies)


### PR DESCRIPTION
For now, any details for scoped packages won't be reported, since we don't have a good way to know if it's a fully private package, or a publicly scoped package, without leaking details of the package (whether to Scarf or to npm). We'll add some functionality to get publicly scoped package data soon. 