### PR TITLE
Rate limit for user facing messages across all scarf-js installations

### DIFF
--- a/report.js
+++ b/report.js
@@ -158,7 +158,7 @@ async function reportPostInstall () {
 
           const timeout1 = setTimeout(() => {
             console.log('')
-            console.log(`No opt in received, skipping analytics`)
+            console.log('No opt in received, skipping analytics')
             reject(new Error('Timeout waiting for user opt in'))
           }, 7000)
 
@@ -329,7 +329,7 @@ async function savePreferencesToRootPackage (path, optIn) {
   temp file. Before logging something to the user, we will verify we're not over
   the rate limit.
 */
-function rateLimitedUserLog(rateLimitKey, toLog) {
+function rateLimitedUserLog (rateLimitKey, toLog) {
   const history = getRateLimitedLogHistory()
   if (!hasHitRateLimit(rateLimitKey, history)) {
     writeCurrentTimeToLogHistory(rateLimitKey, history)
@@ -339,7 +339,7 @@ function rateLimitedUserLog(rateLimitKey, toLog) {
   }
 }
 
-function getRateLimitedLogHistory() {
+function getRateLimitedLogHistory () {
   let history
   try {
     history = JSON.parse(fs.readFileSync(tmpFileName))
@@ -350,7 +350,7 @@ function getRateLimitedLogHistory() {
 }
 
 //  Current rate limit: 1/minute
-function hasHitRateLimit(rateLimitKey, history) {
+function hasHitRateLimit (rateLimitKey, history) {
   if (!history || !history[rateLimitKey]) {
     return false
   }
@@ -359,7 +359,7 @@ function hasHitRateLimit(rateLimitKey, history) {
   return (new Date().getTime() - lastLog) < userMessageThrottleTime
 }
 
-function writeCurrentTimeToLogHistory(rateLimitKey, history) {
+function writeCurrentTimeToLogHistory (rateLimitKey, history) {
   history[rateLimitKey] = new Date().getTime()
   fs.writeFileSync(tmpFileName, JSON.stringify(history))
 }

--- a/report.js
+++ b/report.js
@@ -10,7 +10,12 @@ const scarfHost = localDevPort ? 'localhost' : 'scarf.sh'
 const scarfLibName = '@scarf/scarf'
 
 const rootPath = path.resolve(__dirname).split('node_modules')[0]
-const tmpFileName = `${os.tmpdir()}/scarf-js-history.log`
+// Pulled into a function for test mocking
+function tmpFileName () {
+  // throttle per user
+  const username = os.userInfo().username
+  return path.join(os.tmpdir(), `scarf-js-history-${username}.log`)
+}
 
 const userMessageThrottleTime = 1000 * 60 // 1 minute
 
@@ -342,7 +347,7 @@ function rateLimitedUserLog (rateLimitKey, toLog) {
 function getRateLimitedLogHistory () {
   let history
   try {
-    history = JSON.parse(fs.readFileSync(tmpFileName))
+    history = JSON.parse(fs.readFileSync(tmpFileName()))
   } catch (e) {
     logIfVerbose(e)
   }
@@ -361,7 +366,7 @@ function hasHitRateLimit (rateLimitKey, history) {
 
 function writeCurrentTimeToLogHistory (rateLimitKey, history) {
   history[rateLimitKey] = new Date().getTime()
-  fs.writeFileSync(tmpFileName, JSON.stringify(history))
+  fs.writeFileSync(tmpFileName(), JSON.stringify(history))
 }
 
 if (require.main === module) {

--- a/report.js
+++ b/report.js
@@ -12,6 +12,8 @@ const scarfLibName = '@scarf/scarf'
 const rootPath = path.resolve(__dirname).split('node_modules')[0]
 const tmpFileName = `${os.tmpdir()}/scarf-js-history.log`
 
+const userMessageThrottleTime = 1000 * 60 // 1 minute
+
 const makeDefaultSettings = () => {
   return {
     defaultOptIn: true
@@ -342,13 +344,12 @@ function getRateLimitedLogHistory() {
 
 //  Current rate limit: 1/minute
 function hasHitRateLimit(history) {
-  const threshold = 1000 * 60
   if (!history || !history.lastRateLimitedLog) {
     return false
   }
 
   const lastLog = history.lastRateLimitedLog
-  return (new Date().getTime() - lastLog) < threshold
+  return (new Date().getTime() - lastLog) < userMessageThrottleTime
 }
 
 function writeCurrentTimeToLogHistory(history) {


### PR DESCRIPTION
### Problem

If a dependency tree has many packages that depend on Scarf, analytics will fire many times, and many messages will be printed. This could result in spamming the build output and might be generally annoying.

### Solution

A system-wide rate limit for Scarf's user-facing messages. Now, when `report.js` runs, it will read from a pre-defined temp file path to check if a user-facing message has been printed within the last minute. If we have, we'll suppress the message. Otherwise, we'll print the message, and record the current timestamp to the temp file. Any other scarf-js instances that execute after in the current build will do the same, and spamming the user will have been prevented.

Throttles are namespaced by opt-in and opt-out so that throttling of the two (and any future categories) don't collide. This avoids an issue where printing a message informing you that analytics _are_ happening doesn't prevent a message asking you to enable them for another package that doesn't have them by default.