### PR TITLE
Add timeout to exec(npm ls) call

### DIFF
--- a/report.js
+++ b/report.js
@@ -18,6 +18,7 @@ function tmpFileName () {
 }
 
 const userMessageThrottleTime = 1000 * 60 // 1 minute
+const execTimeout = 3000
 
 // In general, these keys should never change to remain backwards compatible
 // with previous versions of Scarf. If we need to update them, we'll need to
@@ -72,7 +73,7 @@ function redactSensitivePackageInfo (dependencyInfo) {
 
 async function getDependencyInfo () {
   return new Promise((resolve, reject) => {
-    exec(`cd ${rootPath} && npm ls @scarf/scarf --json --long`, function (error, stdout, stderr) {
+    exec(`cd ${rootPath} && npm ls @scarf/scarf --json --long`, { timeout: execTimeout }, function (error, stdout, stderr) {
       if (error) {
         return reject(new Error(`Scarf received an error from npm -ls: ${error}`))
       }


### PR DESCRIPTION
For projects with lots of dependencies, this `npm ls` call can take a very long time, which can cause installs to hang. Here, we'll set a timeout on that call if it takes > 3 seconds

Issues raised in https://github.com/tannerlinsley/react-table/issues/2215