### PR TITLE
Intermediate package opt out

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@scarf/scarf",
-  "version": "0.1.5",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "files": [
     "report.js",
-    "test/*.js"
+    "test/*"
   ],
   "scripts": {
     "postinstall": "node ./report.js",

--- a/report.js
+++ b/report.js
@@ -76,9 +76,8 @@ function redactSensitivePackageInfo (dependencyInfo) {
   return dependencyInfo
 }
 
-function processDependencyTreeOutput(resolve, reject) {
+function processDependencyTreeOutput (resolve, reject) {
   return function (error, stdout, stderr) {
-    debugger
     if (error) {
       return reject(new Error(`Scarf received an error from npm -ls: ${error}`))
     }
@@ -102,7 +101,7 @@ function processDependencyTreeOutput(resolve, reject) {
           rootPackage: rootPackageDetails,
           anyInChainDisabled: depChain.some(dep => {
             return (dep.scarfSettings || {}).enabled === false
-          }),
+          })
         }
       })
 
@@ -119,7 +118,7 @@ function processDependencyTreeOutput(resolve, reject) {
       // If any intermediate dependency in the chain of deps that leads to scarf
       // has disabled Scarf, we must respect that setting
       if (dependencyToReport.anyInChainDisabled) {
-        return reject(new Error(`Scarf has been disabled via a package.json in the dependency chain.`))
+        return reject(new Error('Scarf has been disabled via a package.json in the dependency chain.'))
       }
 
       return resolve(dependencyToReport)
@@ -427,5 +426,5 @@ module.exports = {
   rateLimitedUserLog,
   tmpFileName,
   dirName,
-  processDependencyTreeOutput,
+  processDependencyTreeOutput
 }

--- a/report.js
+++ b/report.js
@@ -17,6 +17,11 @@ function tmpFileName () {
   return path.join(os.tmpdir(), `scarf-js-history-${username}.log`)
 }
 
+// Pulled into a function for test mocking
+function dirName () {
+  return __dirname
+}
+
 const userMessageThrottleTime = 1000 * 60 // 1 minute
 const execTimeout = 3000
 
@@ -71,49 +76,63 @@ function redactSensitivePackageInfo (dependencyInfo) {
   return dependencyInfo
 }
 
+function processDependencyTreeOutput(resolve, reject) {
+  return function (error, stdout, stderr) {
+    debugger
+    if (error) {
+      return reject(new Error(`Scarf received an error from npm -ls: ${error}`))
+    }
+
+    try {
+      const output = JSON.parse(stdout)
+
+      let depsToScarf = findScarfInFullDependencyTree(output)
+      depsToScarf = depsToScarf.filter(depChain => depChain.length > 2)
+      if (depsToScarf.length === 0) {
+        return reject(new Error('No Scarf parent package found'))
+      }
+
+      const rootPackageDetails = rootPackageDepInfo(output)
+
+      const dependencyInfo = depsToScarf.map(depChain => {
+        return {
+          scarf: depChain[depChain.length - 1],
+          parent: depChain[depChain.length - 2],
+          grandparent: depChain[depChain.length - 3],
+          rootPackage: rootPackageDetails,
+          anyInChainDisabled: depChain.some(dep => {
+            return (dep.scarfSettings || {}).enabled === false
+          }),
+        }
+      })
+
+      dependencyInfo.forEach(d => {
+        d.parent.scarfSettings = Object.assign(makeDefaultSettings(), d.parent.scarfSettings || {})
+      })
+
+      // Here, we find the dependency chain that corresponds to the scarf package we're currently in
+      const dependencyToReport = dependencyInfo.find(dep => (dep.scarf.path === module.exports.dirName()))
+      if (!dependencyToReport) {
+        return reject(new Error(`Couldn't find dependency info for path ${module.exports.dirName()}`))
+      }
+
+      // If any intermediate dependency in the chain of deps that leads to scarf
+      // has disabled Scarf, we must respect that setting
+      if (dependencyToReport.anyInChainDisabled) {
+        return reject(new Error(`Scarf has been disabled via a package.json in the dependency chain.`))
+      }
+
+      return resolve(dependencyToReport)
+    } catch (err) {
+      logIfVerbose(err, console.error)
+      return reject(err)
+    }
+  }
+}
+
 async function getDependencyInfo () {
   return new Promise((resolve, reject) => {
-    exec(`cd ${rootPath} && npm ls @scarf/scarf --json --long`, { timeout: execTimeout }, function (error, stdout, stderr) {
-      if (error) {
-        return reject(new Error(`Scarf received an error from npm -ls: ${error}`))
-      }
-
-      try {
-        const output = JSON.parse(stdout)
-
-        let depsToScarf = findScarfInFullDependencyTree(output)
-        depsToScarf = depsToScarf.filter(depChain => depChain.length > 2)
-        if (depsToScarf.length === 0) {
-          return reject(new Error('No Scarf parent package found'))
-        }
-
-        const rootPackageDetails = rootPackageDepInfo(output)
-
-        const dependencyInfo = depsToScarf.map(depChain => {
-          return {
-            scarf: depChain[depChain.length - 1],
-            parent: depChain[depChain.length - 2],
-            grandparent: depChain[depChain.length - 3], // might be undefined
-            rootPackage: rootPackageDetails
-          }
-        })
-
-        dependencyInfo.forEach(d => {
-          d.parent.scarfSettings = Object.assign(makeDefaultSettings(), d.parent.scarfSettings || {})
-        })
-
-        // Here, we find the dependency chain that corresponds to the scarf package we're currently in
-        const dependencyToReport = dependencyInfo.find(dep => (dep.scarf.path === __dirname))
-        if (!dependencyToReport) {
-          return reject(new Error(`Couldn't find dependency info for path ${__dirname}`))
-        }
-
-        return resolve(dependencyToReport)
-      } catch (err) {
-        logIfVerbose(err, console.error)
-        return reject(err)
-      }
-    })
+    exec(`cd ${rootPath} && npm ls @scarf/scarf --json --long`, { timeout: execTimeout }, processDependencyTreeOutput(resolve, reject))
   })
 }
 
@@ -406,5 +425,7 @@ module.exports = {
   hasHitRateLimit,
   getRateLimitedLogHistory,
   rateLimitedUserLog,
-  tmpFileName
+  tmpFileName,
+  dirName,
+  processDependencyTreeOutput,
 }

--- a/test/example-ls-output.json
+++ b/test/example-ls-output.json
@@ -1,0 +1,108 @@
+{
+  "name": "scarfed-lib-consumer-consumer",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "scarfed-lib-consumer": {
+      "_from": "file:/tmp/scarfed-lib-consumer-9.9.9.tgz",
+      "_id": "scarfed-lib-consumer@9.9.9",
+      "_location": "/scarfed-lib-consumer",
+      "_requiredBy": [
+        "/"
+      ],
+      "_resolved": "/tmp/scarfed-lib-consumer-9.9.9.tgz",
+      "_spec": "file:../../../../tmp/scarfed-lib-consumer-9.9.9.tgz",
+      "_where": "/path/scarfed-lib-consumer-consumer",
+      "author": "",
+      "bundleDependencies": false,
+      "dependencies": {
+        "scarfed-library": {
+          "_from": "file:/tmp/scarfed-library-1.0.0.tgz",
+          "_id": "scarfed-library@1.0.0",
+          "_location": "/scarfed-library",
+          "_requiredBy": [
+            "/scarfed-lib-consumer"
+          ],
+          "_resolved": "/tmp/scarfed-library-1.0.0.tgz",
+          "_spec": "file:../../../../tmp/scarfed-library-1.0.0.tgz",
+          "_where": "/path/scarfed-lib-consumer-consumer",
+          "author": "",
+          "bundleDependencies": false,
+          "dependencies": {
+            "@scarf/scarf": {
+              "_from": "file:/tmp/scarf-scarf-1.0.3.tgz",
+              "_id": "@scarf/scarf@1.0.3",
+              "_location": "/@scarf/scarf",
+              "_phantomChildren": {},
+              "_requiredBy": [
+                "/scarfed-library"
+              ],
+              "_resolved": "/tmp/scarf-scarf-1.0.3.tgz",
+              "_where": "/path/scarfed-lib-consumer-consumer",
+              "files": [
+                "report.js",
+                "test/*.js"
+              ],
+              "version": "1.0.3",
+              "dependencies": {},
+              "optionalDependencies": {},
+              "_dependencies": {},
+              "path": "/path/scarfed-lib-consumer-consumer/node_modules/@scarf/scarf",
+              "error": null,
+              "extraneous": false,
+              "_parent": "[Circular]",
+              "_found": "explicit"
+            }
+          },
+          "deprecated": false,
+          "main": "index.js",
+          "name": "scarfed-library",
+          "scarfSettings": {
+            "defaultOptIn": true
+          },
+          "scripts": {
+            "test": "echo \"Error: no test specified\" && exit 1"
+          },
+          "version": "1.0.0",
+          "readme": "ERROR: No README data found!",
+          "_args": [
+            [
+              "scarfed-library@file:../../../../tmp/scarfed-library-1.0.0.tgz",
+              "/path/scarfed-lib-consumer-consumer"
+            ]
+          ],
+          "devDependencies": {},
+          "optionalDependencies": {},
+          "_dependencies": {
+            "@scarf/scarf": "file:///tmp/scarf-scarf-1.0.3.tgz"
+          },
+          "path": "/path/scarfed-lib-consumer-consumer/node_modules/scarfed-library",
+          "error": "[Circular]",
+          "extraneous": false,
+          "_parent": "[Circular]",
+          "_found": "implicit"
+        }
+      },
+      "deprecated": false,
+      "main": "index.js",
+      "name": "scarfed-lib-consumer",
+      "scarfSettings": {
+        "enabled": false
+      },
+      "version": "9.9.9",
+      "_dependencies": {
+        "scarfed-library": "file:///tmp/scarfed-library-1.0.0.tgz"
+      },
+      "path": "/path/scarfed-lib-consumer-consumer/node_modules/scarfed-lib-consumer"
+    }
+  },
+  "_id": "scarfed-lib-consumer-consumer@1.0.0",
+  "_dependencies": {
+    "scarfed-lib-consumer": "file:///tmp/scarfed-lib-consumer-9.9.9.tgz"
+  },
+  "path": "/path/scarfed-lib-consumer-consumer"
+}

--- a/test/report.test.js
+++ b/test/report.test.js
@@ -16,7 +16,6 @@ describe('Reporting tests', () => {
     report.tmpFileName = jest.fn(() => {
       return tmpFileReturnVal
     })
-    debugger
     report.dirName = jest.fn(() => {
       return scarfExecPath
     })
@@ -69,13 +68,13 @@ describe('Reporting tests', () => {
     expect(redacted.parent.version).toBe('1.0.0')
   })
 
-  test('Intermediate packages can disabled Scarf for their dependents', async () => {
+  test('Intermediate packages can disable Scarf for their dependents', async () => {
     const exampleLsOutput = fs.readFileSync('./test/example-ls-output.json')
     await expect(new Promise((resolve, reject) => {
       return report.processDependencyTreeOutput(resolve, reject)(null, exampleLsOutput, null)
-    })).rejects.toEqual(new Error(`Scarf has been disabled via a package.json in the dependency chain.`))
+    })).rejects.toEqual(new Error('Scarf has been disabled via a package.json in the dependency chain.'))
     const parsedLsOutput = JSON.parse(exampleLsOutput)
-    delete(parsedLsOutput.dependencies['scarfed-lib-consumer'].scarfSettings)
+    delete (parsedLsOutput.dependencies['scarfed-lib-consumer'].scarfSettings)
 
     await new Promise((resolve, reject) => {
       return report.processDependencyTreeOutput(resolve, reject)(null, JSON.stringify(parsedLsOutput), null)


### PR DESCRIPTION
Closes #18 

This change ensures that packages that depend on packages that depend on Scarf can disabled Scarf for their own users and downstream dependents, as described in #18.