### PR TITLE
Disable scarf-js analytics when yarn is the installing package manager

### DIFF
--- a/report.js
+++ b/report.js
@@ -434,7 +434,7 @@ module.exports = {
   processDependencyTreeOutput,
   npmExecPath,
   getDependencyInfo,
-  reportPostInstall,
+  reportPostInstall
 }
 
 if (require.main === module) {
@@ -451,4 +451,3 @@ if (require.main === module) {
     process.exit(0)
   }
 }
-

--- a/report.js
+++ b/report.js
@@ -161,7 +161,7 @@ async function reportPostInstall () {
   const rootPackage = dependencyInfo.rootPackage
 
   if (!userHasOptedIn(rootPackage) && isYarn()) {
-    return Promise.reject(new Error('Package manager is yarn, Scarf is unable to inform user of analytics. Aborting.'))
+    return Promise.reject(new Error('Package manager is yarn. scarf-js is unable to inform user of analytics. Aborting.'))
   }
 
   await new Promise((resolve, reject) => {
@@ -173,7 +173,7 @@ async function reportPostInstall () {
       if (!userHasOptedIn(rootPackage)) {
         rateLimitedUserLog(optedInLogRateLimitKey, `
     The dependency '${dependencyInfo.parent.name}' is tracking installation
-    statistics using Scarf (https://scarf.sh), which helps open-source developers
+    statistics using scarf-js (https://scarf.sh), which helps open-source developers
     fund and maintain their projects. Scarf securely logs basic installation
     details when this package is installed. The Scarf npm library is open source
     and permissively licensed at https://github.com/scarf-sh/scarf-js. For more
@@ -192,7 +192,7 @@ async function reportPostInstall () {
           }
           rateLimitedUserLog(optedOutLogRateLimitKey, `
     The dependency '${dependencyInfo.parent.name}' would like to track
-    installation statistics using Scarf (https://scarf.sh), which helps
+    installation statistics using scarf-js (https://scarf.sh), which helps
     open-source developers fund and maintain their projects. Reporting is disabled
     by default for this package. When enabled, Scarf securely logs basic
     installation details when this package is installed. The Scarf npm library is

--- a/report.js
+++ b/report.js
@@ -424,6 +424,19 @@ function writeCurrentTimeToLogHistory (rateLimitKey, history) {
   fs.writeFileSync(module.exports.tmpFileName(), JSON.stringify(history))
 }
 
+module.exports = {
+  redactSensitivePackageInfo,
+  hasHitRateLimit,
+  getRateLimitedLogHistory,
+  rateLimitedUserLog,
+  tmpFileName,
+  dirName,
+  processDependencyTreeOutput,
+  npmExecPath,
+  getDependencyInfo,
+  reportPostInstall,
+}
+
 if (require.main === module) {
   try {
     reportPostInstall().catch(e => {
@@ -439,15 +452,3 @@ if (require.main === module) {
   }
 }
 
-module.exports = {
-  redactSensitivePackageInfo,
-  hasHitRateLimit,
-  getRateLimitedLogHistory,
-  rateLimitedUserLog,
-  tmpFileName,
-  dirName,
-  processDependencyTreeOutput,
-  npmExecPath,
-  getDependencyInfo,
-  reportPostInstall
-}


### PR DESCRIPTION
closes #17 

Until we can address full yarn support (#3), Scarf is unable to actually log to the console when the user is installing through yarn. This change fully disables scarf-js inside of yarn-initiated installations, by checking the `npm_execpath` environment variable.