### PR TITLE
Set maxBuffer for Dependency tree output

### DIFF
--- a/report.js
+++ b/report.js
@@ -166,7 +166,7 @@ function processDependencyTreeOutput (resolve, reject) {
 
 async function getDependencyInfo () {
   return new Promise((resolve, reject) => {
-    exec(`cd ${rootPath} && npm ls @scarf/scarf --json --long`, { timeout: execTimeout }, processDependencyTreeOutput(resolve, reject))
+    exec(`cd ${rootPath} && npm ls @scarf/scarf --json --long`, { timeout: execTimeout, maxBuffer: 1024 * 1024 * 1024 }, processDependencyTreeOutput(resolve, reject))
   })
 }
 


### PR DESCRIPTION
Tried to use scarf for my project botium-bindings.
I am receiving this error message on _npm install_:

    SyntaxError: Unexpected end of JSON input
        at JSON.parse (<anonymous>)
        at /home/ftreml/dev/botium-bindings/node_modules/@scarf/scarf/report.js:122:27
        at ChildProcess.exithandler (child_process.js:301:5)
        at ChildProcess.emit (events.js:198:13)
        at maybeClose (internal/child_process.js:982:16)
        at Process.ChildProcess._handle.onexit (internal/child_process.js:259:5)

Seems that the stdout stream for _npm -ls_ (dependency tree) is truncated. 

Possible fix: add _maxBuffer_  to child process options.