### PR TITLE
Enable analytics when target package has no parent. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,20 @@ to opt in.
 Regardless of the default state, Scarf will log what it is doing to users who
 haven't explictly opted in or out.
 
+By default, scarf-js will only trigger analytics when your package is installed as a dependency of another package, or is being installed globally. This ensures that scarf-js analytics will not be triggered on `npm install` being run _within your project_. To change this, you can add:
+
+```json5
+// your-package/package.json
+
+{
+  // ...
+  "scarfSettings": {
+    "allowTopLevel": true
+  }
+  // ...
+}
+```
+
 ### FAQ
 
 #### What information does scarf-js provide me as a package author?

--- a/report.js
+++ b/report.js
@@ -29,6 +29,7 @@ function npmExecPath () {
 }
 
 const userMessageThrottleTime = 1000 * 60 // 1 minute
+
 const execTimeout = 3000
 
 // In general, these keys should never change to remain backwards compatible
@@ -57,6 +58,26 @@ const userHasOptedOut = (rootPackage) => {
 
 const userHasOptedIn = (rootPackage) => {
   return (rootPackage && rootPackage.scarfSettings && rootPackage.scarfSettings.enabled) || process.env.SCARF_ANALYTICS === 'true'
+}
+
+// Packages that depend on Scarf can configure whether to should fire when
+// `npm install` is being run directly from within the package, rather than from a
+// dependent package
+function allowTopLevel (rootPackage) {
+  return rootPackage && rootPackage.scarfSettings && rootPackage.scarfSettings.allowTopLevel
+}
+
+function parentIsRoot(dependencyToReport) {
+  return dependencyToReport.parent.name === dependencyToReport.rootPackage.name &&
+    dependencyToReport.parent.version === dependencyToReport.rootPackage.version
+}
+
+function isTopLevel(dependencyToReport) {
+  return parentIsRoot(dependencyToReport) && !process.env.npm_config_global
+}
+
+function isGlobal(dependencyToReport) {
+  return parentIsRoot(dependencyToReport) && !!process.env.npm_config_global
 }
 
 function hashWithDefault (toHash, defaultReturn) {
@@ -120,12 +141,10 @@ function processDependencyTreeOutput (resolve, reject) {
     try {
       const output = JSON.parse(stdout)
 
-      let depsToScarf = findScarfInFullDependencyTree(output)
-      depsToScarf = depsToScarf.filter(depChain => depChain.length > 2)
-      if (depsToScarf.length === 0) {
-        return reject(new Error('No Scarf parent package found'))
+      let depsToScarf = findScarfInFullDependencyTree(output).filter(depChain => depChain.length >= 2)
+      if (!depsToScarf.length) {
+        return reject(new Error(`No Scarf parent package found`))
       }
-
       const rootPackageDetails = rootPackageDepInfo(output)
 
       const dependencyInfo = depsToScarf.map(depChain => {
@@ -145,7 +164,7 @@ function processDependencyTreeOutput (resolve, reject) {
       })
 
       // Here, we find the dependency chain that corresponds to the scarf package we're currently in
-      const dependencyToReport = dependencyInfo.find(dep => (dep.scarf.path === module.exports.dirName()))
+      const dependencyToReport = dependencyInfo.find(dep => (dep.scarf.path === module.exports.dirName())) || dependencyInfo[0]
       if (!dependencyToReport) {
         return reject(new Error(`Couldn't find dependency info for path ${module.exports.dirName()}`))
       }
@@ -154,6 +173,10 @@ function processDependencyTreeOutput (resolve, reject) {
       // has disabled Scarf, we must respect that setting unless the user overrides it.
       if (dependencyToReport.anyInChainDisabled && !userHasOptedIn(dependencyToReport.rootPackage)) {
         return reject(new Error('Scarf has been disabled via a package.json in the dependency chain.'))
+      }
+
+      if (isTopLevel(dependencyToReport) && !isGlobal(dependencyToReport) && !allowTopLevel(rootPackageDetails)) {
+        return reject(new Error('The package depending on Scarf is the root package being installed, but Scarf is not configured to run in this case. To enable it, set `scarfSettings.allowTopLevel = true` in your package.json'))
       }
 
       return resolve(dependencyToReport)
@@ -175,7 +198,7 @@ async function reportPostInstall () {
 
   const dependencyInfo = await module.exports.getDependencyInfo()
   if (!dependencyInfo.parent || !dependencyInfo.parent.name) {
-    return Promise.reject(new Error('No parent, nothing to report'))
+    return Promise.reject(new Error('No parent found, nothing to report'))
   }
 
   const rootPackage = dependencyInfo.rootPackage
@@ -388,6 +411,9 @@ function packageDetailsFromDepInfo (tree) {
 }
 
 function rootPackageDepInfo (packageInfo) {
+  if (process.env.npm_config_global) {
+    packageInfo = Object.values(packageInfo.dependencies)[0]
+  }
   const info = packageDetailsFromDepInfo(packageInfo)
   info.packageJsonPath = `${packageInfo.path}/package.json`
   return info
@@ -455,7 +481,8 @@ module.exports = {
   npmExecPath,
   getDependencyInfo,
   reportPostInstall,
-  hashWithDefault
+  hashWithDefault,
+  findScarfInFullDependencyTree
 }
 
 if (require.main === module) {

--- a/report.js
+++ b/report.js
@@ -67,16 +67,16 @@ function allowTopLevel (rootPackage) {
   return rootPackage && rootPackage.scarfSettings && rootPackage.scarfSettings.allowTopLevel
 }
 
-function parentIsRoot(dependencyToReport) {
+function parentIsRoot (dependencyToReport) {
   return dependencyToReport.parent.name === dependencyToReport.rootPackage.name &&
     dependencyToReport.parent.version === dependencyToReport.rootPackage.version
 }
 
-function isTopLevel(dependencyToReport) {
+function isTopLevel (dependencyToReport) {
   return parentIsRoot(dependencyToReport) && !process.env.npm_config_global
 }
 
-function isGlobal(dependencyToReport) {
+function isGlobal (dependencyToReport) {
   return parentIsRoot(dependencyToReport) && !!process.env.npm_config_global
 }
 
@@ -141,9 +141,9 @@ function processDependencyTreeOutput (resolve, reject) {
     try {
       const output = JSON.parse(stdout)
 
-      let depsToScarf = findScarfInFullDependencyTree(output).filter(depChain => depChain.length >= 2)
+      const depsToScarf = findScarfInFullDependencyTree(output).filter(depChain => depChain.length >= 2)
       if (!depsToScarf.length) {
-        return reject(new Error(`No Scarf parent package found`))
+        return reject(new Error('No Scarf parent package found'))
       }
       const rootPackageDetails = rootPackageDepInfo(output)
 

--- a/test/report.test.js
+++ b/test/report.test.js
@@ -121,6 +121,32 @@ describe('Reporting tests', () => {
       expect(err.message).toContain('yarn')
     }
   })
+
+  test('Configurable for top level installs, and enabled for global installs', async () => {
+    const parsedLsOutput = dependencyTreeTopLevelInstall()
+
+    await expect(new Promise((resolve, reject) => {
+        return report.processDependencyTreeOutput(resolve, reject)(null, JSON.stringify(parsedLsOutput), null)
+    })).rejects.toEqual(new Error('The package depending on Scarf is the root package being installed, but Scarf is not configured to run in this case. To enable it, set `scarfSettings.allowTopLevel = true` in your package.json'))
+
+    process.env.npm_config_global = true
+
+    await expect(new Promise((resolve, reject) => {
+      return report.processDependencyTreeOutput(resolve, reject)(null, JSON.stringify(parsedLsOutput), null)
+    })).toBeTruthy()
+
+    process.env.npm_config_global = ''
+    parsedLsOutput.scarfSettings = {allowTopLevel: true}
+
+    await expect(new Promise((resolve, reject) => {
+      return report.processDependencyTreeOutput(resolve, reject)(null, JSON.stringify(parsedLsOutput), null)
+    })).toBeTruthy()
+
+    parsedLsOutput.scarfSettings = {allowTopLevel: false}
+    await expect(new Promise((resolve, reject) => {
+      return report.processDependencyTreeOutput(resolve, reject)(null, JSON.stringify(parsedLsOutput), null)
+    })).rejects.toEqual(new Error('The package depending on Scarf is the root package being installed, but Scarf is not configured to run in this case. To enable it, set `scarfSettings.allowTopLevel = true` in your package.json'))
+  })
 })
 
 function dependencyTreeScarfEnabled () {
@@ -129,5 +155,11 @@ function dependencyTreeScarfEnabled () {
   const parsedLsOutput = JSON.parse(exampleLsOutput)
   delete (parsedLsOutput.dependencies['scarfed-lib-consumer'].scarfSettings)
 
+  return parsedLsOutput
+}
+
+function dependencyTreeTopLevelInstall () {
+  const exampleLsOutput = fs.readFileSync('./test/top-level-package-ls-output.json')
+  const parsedLsOutput = JSON.parse(exampleLsOutput)
   return parsedLsOutput
 }

--- a/test/report.test.js
+++ b/test/report.test.js
@@ -126,7 +126,7 @@ describe('Reporting tests', () => {
     const parsedLsOutput = dependencyTreeTopLevelInstall()
 
     await expect(new Promise((resolve, reject) => {
-        return report.processDependencyTreeOutput(resolve, reject)(null, JSON.stringify(parsedLsOutput), null)
+      return report.processDependencyTreeOutput(resolve, reject)(null, JSON.stringify(parsedLsOutput), null)
     })).rejects.toEqual(new Error('The package depending on Scarf is the root package being installed, but Scarf is not configured to run in this case. To enable it, set `scarfSettings.allowTopLevel = true` in your package.json'))
 
     process.env.npm_config_global = true
@@ -136,13 +136,13 @@ describe('Reporting tests', () => {
     })).toBeTruthy()
 
     process.env.npm_config_global = ''
-    parsedLsOutput.scarfSettings = {allowTopLevel: true}
+    parsedLsOutput.scarfSettings = { allowTopLevel: true }
 
     await expect(new Promise((resolve, reject) => {
       return report.processDependencyTreeOutput(resolve, reject)(null, JSON.stringify(parsedLsOutput), null)
     })).toBeTruthy()
 
-    parsedLsOutput.scarfSettings = {allowTopLevel: false}
+    parsedLsOutput.scarfSettings = { allowTopLevel: false }
     await expect(new Promise((resolve, reject) => {
       return report.processDependencyTreeOutput(resolve, reject)(null, JSON.stringify(parsedLsOutput), null)
     })).rejects.toEqual(new Error('The package depending on Scarf is the root package being installed, but Scarf is not configured to run in this case. To enable it, set `scarfSettings.allowTopLevel = true` in your package.json'))

--- a/test/top-level-package-ls-output.json
+++ b/test/top-level-package-ls-output.json
@@ -1,0 +1,115 @@
+{
+  "name": "scarfed-lib-consumer",
+  "version": "9.9.9",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@scarf/scarf": {
+      "_from": "file:/tmp/scarf-scarf-1.0.6.tgz",
+      "_id": "@scarf/scarf@1.0.6",
+      "_integrity": "sha512-YQ7vXVI6G2qLm14rKRWvnvAtcW2dTwCw5ywQWgaNKfqLjteyQqM3pAlIOAQ9C5ShiKwsFavHpwCUkOG7Sfa67A==",
+      "_location": "/@scarf/scarf",
+      "_phantomChildren": {},
+      "_requested": {
+        "type": "file",
+        "where": "/Users/avi/dev/scarfed-lib-consumer",
+        "raw": "@scarf/scarf@file:../../../../tmp/scarf-scarf-1.0.6.tgz",
+        "name": "@scarf/scarf",
+        "escapedName": "@scarf%2fscarf",
+        "scope": "@scarf",
+        "rawSpec": "file:../../../../tmp/scarf-scarf-1.0.6.tgz",
+        "saveSpec": "file:../../../../tmp/scarf-scarf-1.0.6.tgz",
+        "fetchSpec": "/tmp/scarf-scarf-1.0.6.tgz"
+      },
+      "_requiredBy": [
+        "/"
+      ],
+      "_resolved": "/tmp/scarf-scarf-1.0.6.tgz",
+      "_shasum": "57bb2ce26f6aafa6a1ea33f6978d044240412773",
+      "_spec": "file:../../../../tmp/scarf-scarf-1.0.6.tgz",
+      "_where": "/Users/avi/dev/scarfed-lib-consumer",
+      "author": {
+        "name": "Scarf Systems"
+      },
+      "bugs": {
+        "url": "https://github.com/scarf-sh/scarf-js/issues"
+      },
+      "bundleDependencies": false,
+      "deprecated": false,
+      "description": "",
+      "devDependencies": {
+        "jest": "^25.3.0",
+        "minimist": "^1.2.2",
+        "standard": "^14.3.1"
+      },
+      "files": [
+        "report.js",
+        "test/*"
+      ],
+      "homepage": "https://github.com/scarf-sh/scarf-js",
+      "license": "Apache-2.0",
+      "main": "report.js",
+      "name": "@scarf/scarf",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/scarf-sh/scarf-js.git"
+      },
+      "scripts": {
+        "postinstall": "node ./report.js",
+        "test": "jest"
+      },
+      "standard": {
+        "globals": [
+          "expect",
+          "test",
+          "jest",
+          "beforeAll",
+          "afterAll",
+          "describe"
+        ]
+      },
+      "version": "1.0.6",
+      "readme": "",
+      "readmeFilename": "README.md",
+      "_args": [
+        [
+          "@scarf/scarf@file:../../../../tmp/scarf-scarf-1.0.6.tgz",
+          "/Users/avi/dev/scarfed-lib-consumer"
+        ]
+      ],
+      "dependencies": {},
+      "optionalDependencies": {},
+      "_dependencies": {},
+      "path": "/Users/avi/dev/scarfed-lib-consumer/node_modules/@scarf/scarf",
+      "error": null,
+      "extraneous": false
+    }
+  },
+  "readme": "ERROR: No README data found!",
+  "_id": "scarfed-lib-consumer@9.9.9",
+  "_shrinkwrap": {
+    "name": "scarfed-lib-consumer",
+    "version": "9.9.9",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+      "@scarf/scarf": {
+        "version": "file:../../../../tmp/scarf-scarf-1.0.6.tgz",
+        "integrity": "sha512-YQ7vXVI6G2qLm14rKRWvnvAtcW2dTwCw5ywQWgaNKfqLjteyQqM3pAlIOAQ9C5ShiKwsFavHpwCUkOG7Sfa67A=="
+      }
+    }
+  },
+  "devDependencies": {},
+  "optionalDependencies": {},
+  "_dependencies": {
+    "@scarf/scarf": "file:///tmp/scarf-scarf-1.0.6.tgz"
+  },
+  "path": "/Users/avi/dev/scarfed-lib-consumer",
+  "error": "[Circular]",
+  "extraneous": false
+}


### PR DESCRIPTION
global installs (ie `npm install -g <target>`) is now supported, as well as analytics when `npm install` is run from inside the target package (disabled by default)