### PR TITLE
Skip traversal

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,28 @@ By default, scarf-js will only trigger analytics when your package is installed 
 }
 ```
 
+
+*Full Configuration Example*
+
+```json5
+// your-package/package.json
+
+{
+  // ...
+  "scarfSettings": {
+    // Toggles whether Scarf is enabled for this package
+    "enabled": true,
+    // Enables Scarf when users run npm install directly in your repository
+    "allowTopLevel": true,
+    // Users will be opted into analytics by default
+    "defaultOptIn": true,
+    // By default, Scarf searches for its own location in your build's dependency graph to ensure reporting can be done for all packages that depend on it. For large projects with lots of dependencies, generating the dependency graph takes more time than Scarf allots for its entire process, so Scarf will always time out. `skipTraversal` is an optional flag for large applications to skip that traversal entirely. Use this flag with caution and care, as it will break Scarf analytics for all other packages you depend on in your build.
+    "skipTraversal": false
+  }
+  // ...
+}
+```
+
 ### FAQ
 
 #### What information does scarf-js provide me as a package author?

--- a/README.md
+++ b/README.md
@@ -90,7 +90,14 @@ By default, scarf-js will only trigger analytics when your package is installed 
     "allowTopLevel": true,
     // Users will be opted into analytics by default
     "defaultOptIn": true,
-    // By default, Scarf searches for its own location in your build's dependency graph to ensure reporting can be done for all packages that depend on it. For large projects with lots of dependencies, generating the dependency graph takes more time than Scarf allots for its entire process, so Scarf will always time out. `skipTraversal` is an optional flag for large applications to skip that traversal entirely. Use this flag with caution and care, as it will break Scarf analytics for all other packages you depend on in your build.
+    // By default, Scarf searches for its own location in your build's dependency
+    // graph to ensure reporting can be done for all packages using Scarf.
+    // For large projects with lots of dependencies, generating that dependency
+    // graph takes more time than Scarf allots for its entire process, so Scarf
+    // will always time out. `skipTraversal` is an optional flag for large
+    // applications to skip that traversal entirely. Use this flag with caution and
+    // care, as it will break Scarf analytics for all other packages you depend
+    // on in your build.
     "skipTraversal": false
   }
   // ...

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ collect stats on install, no additional code is required!
 
 Head to your package's dashboard on Scarf to see your reports when available.
 
-#### Configuration
+### Configuring
 
 Users of your package will be opted in by default and can opt out by setting the
 `SCARF_ANALYTICS=false` environment variable. If you'd like Scarf analytics to
@@ -76,7 +76,7 @@ By default, scarf-js will only trigger analytics when your package is installed 
 ```
 
 
-*Full Configuration Example*
+#### Full Configuration Example
 
 ```json5
 // your-package/package.json

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
       "jest",
       "beforeAll",
       "afterAll",
+      "fail",
       "describe"
     ]
   }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "scripts": {
     "postinstall": "node ./report.js",
-    "test": "jest"
+    "test": "jest --verbose"
   },
   "author": "Scarf Systems",
   "license": "Apache-2.0",

--- a/report.js
+++ b/report.js
@@ -12,8 +12,7 @@ const scarfLibName = '@scarf/scarf'
 const privatePackageRewrite = '@private/private'
 const privateVersionRewrite = '0'
 
-const rootPath = process.env.INIT_CWD
-// const rootPath = path.resolve(__dirname).split('node_modules')[0]
+const rootPath = path.resolve(__dirname).split('node_modules')[0]
 // Pulled into a function for test mocking
 function tmpFileName () {
   // throttle per user

--- a/report.js
+++ b/report.js
@@ -192,9 +192,11 @@ function processDependencyTreeOutput (resolve, reject) {
   }
 }
 
-async function getDependencyInfo () {
+// packageJSONOverride: a test convenience to set a packageJSON explicitly.
+// Leave empty to use the actual root package.json.
+async function getDependencyInfo (packageJSONOverride) {
   try {
-    const rootPackageJSON = require(path.join(rootPath, 'package.json'))
+    const rootPackageJSON = require(packageJSONOverride || path.join(rootPath, 'package.json'))
     const scarfPackageJSON = require(path.join(dirName(), 'package.json'))
 
     if (skipTraversal(rootPackageJSON)) {
@@ -203,7 +205,8 @@ async function getDependencyInfo () {
         scarf: { name: '@scarf/scarf', version: scarfPackageJSON.version },
         parent: { name: rootPackageJSON.name, version: rootPackageJSON.version },
         rootPackage: { name: rootPackageJSON.name, version: rootPackageJSON.version },
-        anyInChainDisabled: false
+        anyInChainDisabled: false,
+        skippedTraversal: true
       }
       logIfVerbose(util.inspect(shallowDepInfo))
       return shallowDepInfo

--- a/test/skip-traversal-package.json
+++ b/test/skip-traversal-package.json
@@ -1,0 +1,10 @@
+{
+  "name": "test-package",
+  "version": "1.0",
+  "dependencies": {
+    "@scarf/scarf": "*"
+  },
+  "scarfSettings": {
+    "skipTraversal": true
+  }
+}

--- a/test/skip-traversal.test.js
+++ b/test/skip-traversal.test.js
@@ -5,8 +5,8 @@ describe('Skip Traversal Flag', () => {
     const depInfo = await report.getDependencyInfo('./test/skip-traversal-package.json')
     expect(depInfo.skippedTraversal).toBe(true)
     try {
-      await report.getDependencyInfo ()
-      fail("Should fail after parsing the real dependency tree and not seeing a parent")
+      await report.getDependencyInfo()
+      fail('Should fail after parsing the real dependency tree and not seeing a parent')
     } catch {}
   })
 })

--- a/test/skip-traversal.test.js
+++ b/test/skip-traversal.test.js
@@ -1,0 +1,12 @@
+const report = require('../report')
+
+describe('Skip Traversal Flag', () => {
+  test('Can skip npm ls when skipTraversal is enabled', async () => {
+    const depInfo = await report.getDependencyInfo('./test/skip-traversal-package.json')
+    expect(depInfo.skippedTraversal).toBe(true)
+    try {
+      await report.getDependencyInfo ()
+      fail("Should fail after parsing the real dependency tree and not seeing a parent")
+    } catch {}
+  })
+})


### PR DESCRIPTION
Closes #55 

This PR introduces the `skipTraversal` flag, to solve the issue of timeouts on projects with lots of dependencies, as `npm ls` is quite slow. 