### PR TITLE
add node version info to base info reporting

### DIFF
--- a/report.js
+++ b/report.js
@@ -376,6 +376,7 @@ async function reportPostInstall () {
     libraryType: 'npm',
     rawPlatform: os.platform(),
     rawArch: os.arch(),
+    nodeVersion: process.versions.node,
     dependencyInfo: dependencyInfo
   }
 


### PR DESCRIPTION
this can very well end up being overly specific though, see: 

```
Scarf payload: {"libraryType":"npm","rawPlatform":"darwin","rawArch":"arm64","nodeVersion":"18.12.1",[...]
```