### PR TITLE
don't use same object reference in shallow dep info

### DIFF
--- a/report.js
+++ b/report.js
@@ -227,8 +227,8 @@ async function getDependencyInfo (packageJSONOverride) {
       }
       const shallowDepInfo = {
         scarf: { name: '@scarf/scarf', version: scarfPackageJSON.version },
-        parent: rootInfoToReport,
-        rootPackage: rootInfoToReport,
+        parent: { ...rootInfoToReport },
+        rootPackage: { ...rootInfoToReport },
         anyInChainDisabled: false,
         skippedTraversal: true
       }


### PR DESCRIPTION
this causes us to create an invalid parent node that does not parse as a valid request in the API, due to the shared grandparent node being modified: https://github.com/scarf-sh/scarf-js/blob/8bade0e1b1ed705305e016f480beac36abef4cc0/report.js#L118-L128

fixes problems from https://github.com/scarf-sh/scarf-js/pull/60