### PR TITLE
Drop old node versions from CI on darwin

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 18.x, 20.x]
+        node-version: [18.x, 20.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
GitHub actions dropped support for these. It's not ideal to remove these, but we don't currently have a choice to keep the build working on GitHub actions. 

Currently this blocks #70 for no other reason other than CI not passing