### PR TITLE
exclude test directory from npm publish contents

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
     "url": "git+https://github.com/scarf-sh/scarf-js.git"
   },
   "files": [
-    "report.js",
-    "test/*"
+    "report.js"
   ],
   "scripts": {
     "postinstall": "node ./report.js",


### PR DESCRIPTION
do we need the test files for packing?

<img width="734" alt="Screenshot 2024-11-06 at 00 33 59" src="https://github.com/user-attachments/assets/20c4032d-7e3b-423b-81f1-65d0afb561e0">
